### PR TITLE
fix: Resolve errors with typescript files, file copying to temp dir, and correct public URI in HTML file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,16 +32,20 @@ const runWithVite = async (tempDir: string, projectPath: string) => {
         createHtmlEntryFile(tempDir, projectPath);
 
         // @TODO: Optimize this.
-        exec("npm install", { cwd: tempDir }, (error, stdout, stderr) => {
-            if (error) {
-                throw error;
-            }
-            startViteServer(tempDir);
+        exec(
+            "npm install --legacy-peer-deps",
+            { cwd: tempDir },
+            (error, stdout, stderr) => {
+                if (error) {
+                    throw error;
+                }
+                startViteServer(tempDir);
 
-            vscode.window.showInformationMessage(
-                "React app is running with Vite!"
-            );
-        });
+                vscode.window.showInformationMessage(
+                    "React app is running with Vite!"
+                );
+            }
+        );
     } catch (error) {
         vscode.window.showErrorMessage(
             "Failed to run the React app with Vite."

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,7 @@ export function symlinkOrCopyProjectFiles(
         const filePath = path.join(projectPath, file);
 
         if (fs.existsSync(filePath)) {
-            fs.copyFileSync(filePath, tempDir);
+            fs.copyFileSync(filePath, path.join(tempDir, file));
         }
     });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export function createViteConfig(tempDir: string, projectRoot: string): void {
                 outDir: 'dist',
             },
 			esbuild: {
-				loader: "jsx",
+				loader: "tsx",
 				include: new RegExp("src\/.*\.(jsx|tsx|js|ts)$"),
 				exclude: [],
 			},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,10 +123,11 @@ export function createHtmlEntryFile(
 
     if (fs.existsSync(existingIndexHtmlPath)) {
         const htmlContent = fs.readFileSync(existingIndexHtmlPath, "utf8");
-        const updatedHtmlContent = htmlContent.replace(
-            "</body>",
-            `${entryFileScriptTag}</body>`
-        );
+
+        // Append the entry file script tag to the end of the body and replace the %PUBLIC_URL% placeholder with the base URL/path
+        const updatedHtmlContent = htmlContent
+            .replace("</body>", `${entryFileScriptTag}</body>`)
+            .replaceAll("%PUBLIC_URL%", "${import.meta.env.BASE_URL}/public");
 
         fs.writeFileSync(htmlEntryFilePath, updatedHtmlContent, "utf8");
     } else {


### PR DESCRIPTION
This PR fixes three issues and improves the Vite configuration:

- Resolves an error when copying files using fs.copyFileSync due to missing destination file
- Configures Vite's esbuild to use tsx loader instead of jsx
- Updates HTML content to use import.meta.env.BASE_URL for PUBLIC_URL to ensure correct asset resolution in Vite